### PR TITLE
custom values only work when not initialized from NSUserDefaults

### DIFF
--- a/Sources/GZEApplication.m
+++ b/Sources/GZEApplication.m
@@ -476,7 +476,7 @@
     
     // loading default : custom values
     
-    customValues = [[NSUserDefaults standardUserDefaults] objectForKey:KEY_CUSTOM_VALUES];
+    customValues = [[[NSUserDefaults standardUserDefaults] objectForKey:KEY_CUSTOM_VALUES] mutableCopy];
     
     if (customValues == nil)
     {


### PR DESCRIPTION
The customValues object is immutable when retrieved from NSUserDefaults, and therefore you can no longer add/remove keys and values on subsequent runs of the app.

The certificate "name" property is more descriptive than the "key" property.  If you have many certificates on your machine, they may all have the same or nearly indistinguishable "keys" but the "name" will tell you Production/Sandbox and most importantly the app ID for the certificate.
